### PR TITLE
Completed fetching missions PR

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACT_APP_MISSIONS_BASE_URL=https://api.spacexdata.com/v3/missions

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-loading": "^2.0.3",
     "react-redux": "^8.0.4",
     "react-router-dom": "^6.4.1",
     "react-scripts": "5.0.1",

--- a/src/components/Missions/index.js
+++ b/src/components/Missions/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const Missions = () => (
-  <div>
+  <>
     Missions
-  </div>
+  </>
 );
 
 export default Missions;

--- a/src/redux/missionSLice.js
+++ b/src/redux/missionSLice.js
@@ -1,16 +1,38 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
-export const missionSlice = createSlice({
+const url = process.env.REACT_APP_MISSIONS_BASE_URL;
+
+const initialState = {
+  missions: [],
+  loading: false,
+};
+
+export const loadMissions = createAsyncThunk('missions/loadMissions', async () => {
+  const missions = await fetch(url)
+    .then((response) => response.json())
+    .catch((error) => {
+      throw new Error(error);
+    });
+  return missions;
+});
+
+const missionsSlice = createSlice({
   name: 'missions',
-  initialState: {
-    missionData: {},
-    status: 'idle',
-  },
-  reducers: {
-    fetchMissions: (state) => state,
+  initialState,
+  reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(loadMissions.pending, (state) => ({ ...state, loading: true }))
+
+      .addCase(loadMissions.fulfilled, (state, { payload }) => ({
+        ...state,
+        loading: false,
+        missions: payload,
+      }));
   },
 });
 
-export const { fetchMissions } = missionSlice.actions;
+export const getAllMissions = (state) => state.missions.missions;
+export const getStatus = (state) => state.missions.loading;
 
-export default missionSlice.reducer;
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,8 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
-import missionSLice from './missionSLice';
+import missionsSlice from './missionSLice';
 
-export default configureStore({
+const store = configureStore({
   reducer: {
-    missions: missionSLice,
+    missions: missionsSlice,
   },
 });
+
+export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8002,6 +8002,11 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-loading@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-loading/-/react-loading-2.0.3.tgz#e8138fb0c3e4674e481b320802ac7048ae14ffb9"
+  integrity sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==
+
 react-redux@^8.0.4:
   version "8.0.4"
   resolved "https://registry.npmjs.org/react-redux/-/react-redux-8.0.4.tgz"


### PR DESCRIPTION
Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

Once the data are fetched, dispatch an action to store the selected data in Redux store:
- mission_id
- mission_name
- description

NOTE: Make sure you only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation).

- Closes #18 